### PR TITLE
add reset functionality

### DIFF
--- a/src/components/board.vue
+++ b/src/components/board.vue
@@ -26,11 +26,12 @@ const doubleCategories = computed(() => Object.values(categories.value).slice(6)
     <div class="board-frame">
       <QuestionColumn
         v-if="boardState === 'select_single' || boardState === 'select_double'"
-        v-for="questionList in boardState === 'select_single'
+        v-for="(questionList, secondIndex) in boardState === 'select_single'
                                 ? singleCategories
                                 : doubleCategories"
         :questionList="questionList"
         :key="questionList.index"
+        :secondIndex="secondIndex"
       />
       <QuestionDisplay v-else-if="boardState === 'reading'" />
       <FinalDisplay v-else-if="boardState === 'final'" />

--- a/src/components/questionColumn.vue
+++ b/src/components/questionColumn.vue
@@ -1,9 +1,22 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import Question from './question.vue';
+import { asyncSetCategory } from '../utils/getCategory';
+import { useQuestionStore } from '../stores/questionsSlice';
+
 const props = defineProps({
-  questionList: Object
+  questionList: Object,
+  secondIndex: Number
 });
+
+const { setCategoryToLoad } = useQuestionStore();
+const handleReload = () => {
+  const { index } = props.questionList;
+  console.log(index, props.secondIndex);
+  setCategoryToLoad.value(index);
+  asyncSetCategory(index);
+}
+
 </script>
 
 <template>
@@ -12,6 +25,9 @@ const props = defineProps({
       <p>
         {{ props.questionList.title.toUpperCase() }}
       </p>
+      <button @click="handleReload">
+        reset
+      </button>
     </div>
     <div>
       <Question v-for="clue in props.questionList.clues" :clue="clue"/>
@@ -21,6 +37,12 @@ const props = defineProps({
 
 <style lang="scss">
 @use '../variables.scss' as *;
+
+.box.category button {
+  position: absolute;
+  top: 5px;
+  left: calc($boxWidth - 70px);
+}
 
 .box {
   height: $boxHeight;
@@ -42,6 +64,7 @@ const props = defineProps({
 .box.category {
   margin-bottom: $internalMargin;
   color: $primaryWhite;
+  position: relative;
   p {
     text-align: center;
     font-family: sans-serif;

--- a/src/components/questionColumn.vue
+++ b/src/components/questionColumn.vue
@@ -3,6 +3,9 @@ import { computed } from 'vue';
 import Question from './question.vue';
 import { asyncSetCategory } from '../utils/getCategory';
 import { useQuestionStore } from '../stores/questionsSlice';
+import { useGameStore } from '../stores/gameSlice';
+
+const { boardState } = useGameStore();
 
 const props = defineProps({
   questionList: Object,
@@ -11,8 +14,10 @@ const props = defineProps({
 
 const { setCategoryToLoad } = useQuestionStore();
 const handleReload = () => {
-  const { index } = props.questionList;
-  console.log(index, props.secondIndex);
+  const modeAddition = boardState.value === 'select_single'
+    ? 0
+    : 6;
+  const index = props.secondIndex + modeAddition;
   setCategoryToLoad.value(index);
   asyncSetCategory(index);
 }

--- a/src/stores/questionsSlice.ts
+++ b/src/stores/questionsSlice.ts
@@ -30,6 +30,10 @@ export const useQuestionStore = create(set => ({
       },
     }
   })),
+  setCategoryToLoad: (index) => set(state => ({
+      ...state.categories,
+      [index]: loaderCategory
+  })),
   toggleCategoryLock: (index) => set(state => ({
     categories: {
       ...state.categories,

--- a/src/stores/questionsSlice.ts
+++ b/src/stores/questionsSlice.ts
@@ -31,8 +31,13 @@ export const useQuestionStore = create(set => ({
     }
   })),
   setCategoryToLoad: (index) => set(state => ({
-      ...state.categories,
-      [index]: loaderCategory
+      categories: {
+        ...state.categories,
+        [index]: {
+          ...loaderCategory,
+          index
+        }
+      }
   })),
   toggleCategoryLock: (index) => set(state => ({
     categories: {

--- a/src/utils/getCategory.ts
+++ b/src/utils/getCategory.ts
@@ -31,7 +31,7 @@ const getCategory = async () => {
   } else return getCategory();
 }
 
-const asyncSetCategory = async (i) => {
+export const asyncSetCategory = async (i) => {
   const category = await getCategory();
   category.clues = category.clues.slice()
     // standardize value


### PR DESCRIPTION
add setToLoad for categories to provide reactivity to reset, reset by loop index (not object included index -- which is not included on blank entries); add simple filler button to trigger the reset and confirmed functionality for single and double